### PR TITLE
Ability to test localized widget

### DIFF
--- a/test/intro_test.dart
+++ b/test/intro_test.dart
@@ -1,41 +1,16 @@
-// This is a basic Flutter widget test.
-//
-// To perform an interaction with a widget in your test, use the WidgetTester
-// utility that Flutter provides. For example, you can send tap and scroll
-// gestures. You can also use WidgetTester to find child widgets in the widget
-// tree, read text, and verify that the values of widget properties are correct.
-
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter\_localizations/flutter\_localizations.dart';
 
-import 'package:bookoo2/utils/localization.dart' show LocalizationDelegate;
 import 'package:bookoo2/screens/intro.dart';
+import './test_utils.dart' show TestUtils;
 
 void main() {
-  Widget makeTestableWidget({ Widget child }) {
-    return MaterialApp(
-      supportedLocales: [
-        const Locale('en', 'US'),
-      ],
-      localizationsDelegates: [
-        const LocalizationDelegate(),
-        GlobalMaterialLocalizations.delegate,
-        GlobalWidgetsLocalizations.delegate,
-      ],
-      localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
-        return const Locale('en', 'US');
-      },
-      home: child,
-    );
-  }
-
   testWidgets('Widget', (WidgetTester tester) async {
-    await tester.pumpWidget(makeTestableWidget(child: Intro()));
+    await tester.pumpWidget(TestUtils.makeTestableWidget(child: Intro()));
     await tester.pumpAndSettle();
 
-//    expect(find.text('dooboolab'), findsOneWidget);
-//    expect(find.text('1'), findsNothing);
+    expect(find.text('dooboolab'), findsOneWidget);
+    expect(find.text('1'), findsNothing);
 
     print(tester.widgetList(find.byType(Text)));
 

--- a/test/test_utils.dart
+++ b/test/test_utils.dart
@@ -1,0 +1,44 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter\_localizations/flutter\_localizations.dart';
+
+import 'package:bookoo2/utils/localization.dart' show Localization;
+import 'package:bookoo2/screens/intro.dart';
+
+class MyTestDelegate extends LocalizationsDelegate<Localization>{
+  @override
+  bool isSupported(Locale locale) {
+    return true;
+  }
+
+  @override
+  Future<Localization> load(Locale locale) async {
+    return Localization(locale);
+  }
+
+  @override
+  bool shouldReload(LocalizationsDelegate<Localization> old) {
+    return false;
+  }
+}
+
+class TestUtils {
+  static Widget makeTestableWidget({ Widget child }) {
+    return MaterialApp(
+      supportedLocales: [
+        const Locale('en', 'US'),
+      ],
+      localizationsDelegates: [
+        MyTestDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+      ],
+      localeResolutionCallback: (Locale locale, Iterable<Locale> supportedLocales) {
+        return const Locale('en', 'US');
+      },
+      home: child,
+    );
+  }
+}


### PR DESCRIPTION
Able to test `localized widget` with the workaround supported in flutter [issue](https://github.com/flutter/flutter/issues/22193) 🎉
- Separate `test_utils`.