### PR TITLE
feat: Implement [Members] screen

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,6 +70,7 @@ class MyApp extends StatelessWidget {
           subtitle: TextStyle(color: Asset.Colors.mediumGray),
           subhead: TextStyle(color: Colors.white),
           display1: TextStyle(color: Asset.Colors.cloudyBlue),
+          display2: TextStyle(color: Asset.Colors.cloudyBlue),
         ),
       ),
       routes: {

--- a/lib/models/Ledger.dart
+++ b/lib/models/Ledger.dart
@@ -19,6 +19,7 @@ class Ledger {
   String description;
   int people;
   String ownerId;
+  List<String> adminIds;
   List<LedgerItem> items;
   Currency currency;
   // List<User> members;
@@ -27,15 +28,16 @@ class Ledger {
   DateTime deletedAt;
 
   Ledger({
-    this.title,
-    this.color,
+    @required this.title,
+    @required this.color,
+    @required this.currency,
     this.description,
     this.people,
     this.ownerId,
+    this.adminIds,
     this.createdAt,
     this.updatedAt,
     this.items,
-    @required this.currency,
     // this.members,
     this.deletedAt,
   });
@@ -44,6 +46,7 @@ class Ledger {
   String toString() {
     return 'title: $title, color: ${color.toString()}, '
       + 'description: $description, people: $people, ownerId: $ownerId, '
+      + 'adminIds: $adminIds, '
       + 'items: ${items.toString()}, currency: ${currency.toString()}, '
       + 'createdAt: $createdAt, updatedAt: $updatedAt, deletedAt: $deletedAt'
     ;

--- a/lib/models/User.dart
+++ b/lib/models/User.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/widgets.dart';
 enum Membership {
   Owner,
-  Writer,
+  Admin,
   Guest,
 }
 
@@ -16,6 +16,7 @@ class User {
   bool showPhoneNumber;
   String statusMsg;
   List<String> ledgers;
+  Membership membership;
   DateTime createdAt;
   DateTime updatedAt;
   DateTime deletedAt;
@@ -31,8 +32,19 @@ class User {
     this.showPhoneNumber,
     this.statusMsg,
     this.ledgers,
+    this.membership,
     this.createdAt,
     this.updatedAt,
     this.deletedAt,
   });
+
+  void changeMemberShip(int val) {
+    if (Membership.Owner.index == val) {
+      membership = Membership.Owner;
+    } else if (Membership.Admin.index == val) {
+      membership = Membership.Admin;
+    } else {
+      membership = Membership.Guest;
+    }
+  }
 }

--- a/lib/models/User.dart
+++ b/lib/models/User.dart
@@ -1,4 +1,9 @@
 import 'package:flutter/widgets.dart';
+enum Membership {
+  Owner,
+  Writer,
+  Guest,
+}
 
 class User {
   @required String uid;

--- a/lib/screens/ledger_item_add.dart
+++ b/lib/screens/ledger_item_add.dart
@@ -463,7 +463,7 @@ class _LedgerItemAddState extends State<LedgerItemAdd> with TickerProviderStateM
                     Container(
                       child: Text('+ ', style: TextStyle(
                         fontSize: 28,
-                        color: Theme.of(context).textTheme.display1.color,
+                        color: Theme.of(context).textTheme.display2.color,
                       )),
                     ),
                     Expanded(

--- a/lib/screens/ledgers.dart
+++ b/lib/screens/ledgers.dart
@@ -21,7 +21,7 @@ class Ledgers extends StatefulWidget {
 }
 
 class _LedgersState extends State<Ledgers> {
-  final List<ListItem> _items = [
+  final List<ListItem> _fakeLedgers = [
     HeadingItem(
       'display', 'email', 'image'
     ),
@@ -138,9 +138,9 @@ class _LedgersState extends State<Ledgers> {
           children: <Widget>[
             Expanded(
               child: ListView.builder(
-                itemCount: _items.length,
+                itemCount: _fakeLedgers.length,
                 itemBuilder: (context, index) {
-                  final item = _items[index];
+                  final item = _fakeLedgers[index];
                   if (item is HeadingItem) {
                     return ProfileListItem(
                       email: item.email,

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -64,6 +64,38 @@ class _MembersState extends State<Members> {
       ),
       Membership.Guest,
     ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Guest,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Guest,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Guest,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Guest,
+    ),
   ];
 
 

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -32,75 +32,74 @@ class _MembersState extends State<Members> {
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Owner,
       ),
-      Membership.Owner,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Admin,
       ),
-      Membership.Writer,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Admin,
       ),
-      Membership.Writer,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Guest,
       ),
-      Membership.Guest,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Guest,
       ),
-      Membership.Guest,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Guest,
       ),
-      Membership.Guest,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Guest,
       ),
-      Membership.Guest,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Guest,
       ),
-      Membership.Guest,
     ),
     MemberItem(
       User(
         displayName: 'displayName',
         email: 'email@email.com',
         thumbURL: 'url',
+        membership: Membership.Guest,
       ),
-      Membership.Guest,
     ),
   ];
-
 
   @override
   Widget build(BuildContext context) {
@@ -147,13 +146,19 @@ class _MembersState extends State<Members> {
           } else if (item is MemberItem) {
             return MemberListItem(
               user: item.user,
-              membership: item.membership,
-              onPressAuth: () { },
+              onPressAuth: () {
+                General.instance.showMembershipDialog(context, (int val) {
+                  setState(() {
+                    item.user.changeMemberShip(val);
+                  });
+                  Navigator.of(context).pop();
+                }, item.user.membership.index);
+              },
               onPressMember: () {
                 General.instance.navigateScreen(context, MaterialPageRoute(
                   builder: (BuildContext context) => ProfilePeer(
                     user: item.user,
-                  )
+                  ),
                 ));
               },
             );

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,12 +1,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
-import 'package:bookoo2/models/User.dart' show User;
-import 'package:bookoo2/models/User.dart';
+
+import 'package:bookoo2/screens/profile_peer.dart';
+import 'package:bookoo2/utils/general.dart';
 import 'package:bookoo2/shared/member_list_item.dart';
-import 'package:bookoo2/utils/localization.dart';
-import 'package:bookoo2/models/Ledger.dart';
 import 'package:bookoo2/shared/header.dart';
 import 'package:bookoo2/shared/member_list_item.dart' show MemberItem, HeadingItem, ListItem;
+import 'package:bookoo2/models/User.dart' show User;
+import 'package:bookoo2/models/User.dart';
+import 'package:bookoo2/models/Ledger.dart';
+import 'package:bookoo2/utils/localization.dart';
 
 class Members extends StatefulWidget {
   final Ledger ledger;
@@ -145,6 +148,14 @@ class _MembersState extends State<Members> {
             return MemberListItem(
               user: item.user,
               membership: item.membership,
+              onPressAuth: () { },
+              onPressMember: () {
+                General.instance.navigateScreen(context, MaterialPageRoute(
+                  builder: (BuildContext context) => ProfilePeer(
+                    user: item.user,
+                  )
+                ));
+              },
             );
           }
           return null;

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,9 +1,12 @@
-import 'package:bookoo2/utils/localization.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
+import 'package:bookoo2/models/User.dart' show User;
+import 'package:bookoo2/models/User.dart';
+import 'package:bookoo2/shared/member_list_item.dart';
+import 'package:bookoo2/utils/localization.dart';
 import 'package:bookoo2/models/Ledger.dart';
 import 'package:bookoo2/shared/header.dart';
-import 'package:bookoo2/utils/asset.dart' as Asset;
+import 'package:bookoo2/shared/member_list_item.dart' show MemberItem, HeadingItem, ListItem;
 
 class Members extends StatefulWidget {
   final Ledger ledger;
@@ -15,8 +18,54 @@ class Members extends StatefulWidget {
 
 class _MembersState extends State<Members> {
   Ledger _ledger;
-
   _MembersState(this._ledger);
+
+  final List<ListItem> _fakeMembers = [
+    HeadingItem(
+      numOfPeople: 4,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Owner,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Writer,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Writer,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Guest,
+    ),
+    MemberItem(
+      User(
+        displayName: 'displayName',
+        email: 'email@email.com',
+        thumbURL: 'url',
+      ),
+      Membership.Guest,
+    ),
+  ];
+
 
   @override
   Widget build(BuildContext context) {
@@ -42,6 +91,29 @@ class _MembersState extends State<Members> {
             ),
           ),
         ],
+      ),
+      body: ListView.builder(
+        itemCount: _fakeMembers.length,
+        itemBuilder: (context, index) {
+          final item = _fakeMembers[index];
+          if (item is HeadingItem) {
+            return Container(
+              child: Text(
+                _localization.trans('MEMBER'),
+                style: TextStyle(
+                  color: Colors.black,
+                  fontSize: 18,
+                ),
+              ),
+            );
+          } else if (item is MemberItem) {
+            return MemberListItem(
+              user: item.user,
+              membership: item.membership,
+            );
+          }
+          return null;
+        },
       ),
     );
   }

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -1,3 +1,4 @@
+import 'package:bookoo2/shared/edit_text.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
@@ -5,7 +6,8 @@ import 'package:bookoo2/screens/profile_peer.dart';
 import 'package:bookoo2/utils/general.dart';
 import 'package:bookoo2/shared/member_list_item.dart';
 import 'package:bookoo2/shared/header.dart';
-import 'package:bookoo2/shared/member_list_item.dart' show MemberItem, HeadingItem, ListItem;
+import 'package:bookoo2/shared/member_list_item.dart'
+    show MemberItem, HeadingItem, ListItem;
 import 'package:bookoo2/models/User.dart' show User;
 import 'package:bookoo2/models/User.dart';
 import 'package:bookoo2/models/Ledger.dart';
@@ -21,6 +23,9 @@ class Members extends StatefulWidget {
 
 class _MembersState extends State<Members> {
   Ledger _ledger;
+  bool _isSearchMode = false;
+  List<ListItem> _filteredMembers = [];
+
   _MembersState(this._ledger);
 
   final List<ListItem> _fakeMembers = [
@@ -116,7 +121,14 @@ class _MembersState extends State<Members> {
             child: RawMaterialButton(
               padding: EdgeInsets.all(0.0),
               shape: CircleBorder(),
-              onPressed: () {},
+              onPressed: () {
+                setState(() {
+                  _isSearchMode = !_isSearchMode;
+                  if (!_isSearchMode) {
+                    _filteredMembers = _fakeMembers;
+                  }
+                });
+              },
               child: Icon(
                 Icons.search,
                 color: Theme.of(context).textTheme.title.color,
@@ -127,21 +139,45 @@ class _MembersState extends State<Members> {
         ],
       ),
       body: ListView.builder(
-        itemCount: _fakeMembers.length,
+        itemCount: _filteredMembers.length,
         itemBuilder: (context, index) {
-          final item = _fakeMembers[index];
+          final item = _filteredMembers[index];
           if (item is HeadingItem) {
             return Container(
               height: 80,
               padding: EdgeInsets.symmetric(horizontal: 40),
               alignment: Alignment(-1, 0),
-              child: Text(
-                '${_localization.trans('MEMBER')} ${item.numOfPeople}',
-                style: TextStyle(
-                  color: Theme.of(context).textTheme.title.color,
-                  fontSize: 28,
-                ),
-              ),
+              child: _isSearchMode ?? false
+                  ? EditText(
+                      key: Key('member'),
+                      textInputAction: TextInputAction.next,
+                      textHint: _localization.trans('SEARCH_USER_HINT'),
+                      onChanged: (String str) {
+                        setState(() {
+                          _filteredMembers = _fakeMembers.where((list) {
+                            if (list is HeadingItem) {
+                              return true;
+                            }
+                            else if (list is MemberItem) {
+                              return list.user.email
+                                      .toLowerCase()
+                                      .contains(str) ||
+                                  list.user.displayName
+                                      .toLowerCase()
+                                      .contains(str);
+                            }
+                            return false;
+                          }).toList();
+                        });
+                      },
+                    )
+                  : Text(
+                      '${_localization.trans('MEMBER')} ${item.numOfPeople}',
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.title.color,
+                        fontSize: 28,
+                      ),
+                    ),
             );
           } else if (item is MemberItem) {
             return MemberListItem(
@@ -155,11 +191,13 @@ class _MembersState extends State<Members> {
                 }, item.user.membership.index);
               },
               onPressMember: () {
-                General.instance.navigateScreen(context, MaterialPageRoute(
-                  builder: (BuildContext context) => ProfilePeer(
-                    user: item.user,
-                  ),
-                ));
+                General.instance.navigateScreen(
+                    context,
+                    MaterialPageRoute(
+                      builder: (BuildContext context) => ProfilePeer(
+                        user: item.user,
+                      ),
+                    ));
               },
             );
           }

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -98,11 +98,14 @@ class _MembersState extends State<Members> {
           final item = _fakeMembers[index];
           if (item is HeadingItem) {
             return Container(
+              height: 80,
+              padding: EdgeInsets.symmetric(horizontal: 40),
+              alignment: Alignment(-1, 0),
               child: Text(
-                _localization.trans('MEMBER'),
+                '${_localization.trans('MEMBER')} ${item.numOfPeople}',
                 style: TextStyle(
-                  color: Colors.black,
-                  fontSize: 18,
+                  color: Theme.of(context).textTheme.title.color,
+                  fontSize: 28,
                 ),
               ),
             );

--- a/lib/screens/members.dart
+++ b/lib/screens/members.dart
@@ -107,6 +107,12 @@ class _MembersState extends State<Members> {
   ];
 
   @override
+  void initState() {
+    super.initState();
+    _filteredMembers = _fakeMembers;
+  }
+
+  @override
   Widget build(BuildContext context) {
     var _localization = Localization.of(context);
 

--- a/lib/screens/photo_detail.dart
+++ b/lib/screens/photo_detail.dart
@@ -3,17 +3,20 @@ import 'package:flutter/material.dart';
 
 import 'package:bookoo2/models/Photo.dart';
 import 'package:bookoo2/utils/localization.dart' show Localization;
+import 'package:bookoo2/utils/asset.dart' as Asset;
 
 class PhotoDetail extends StatefulWidget {
   PhotoDetail({
     Key key,
-    @required this.photo,
+    this.photo,
+    this.photoUrl,
     this.canShare = false,
     this.onPressDelete,
     this.onPressShare,
     this.onPressDownload,
   }) : super(key: key);
   final Photo photo;
+  final String photoUrl;
   final bool canShare;
   final Function onPressDelete;
   final Function onPressShare;
@@ -33,11 +36,14 @@ class _State extends State<PhotoDetail> {
         child: Stack(
           children: <Widget>[
             PhotoView(
-              imageProvider: widget.photo.file != null
+              imageProvider:
+                widget.photoUrl != null
+                ? NetworkImage(widget.photoUrl)
+                : widget.photo != null && widget.photo.file != null
                 ? FileImage(widget.photo.file)
-                : widget.photo.url != null
-                ? Image.network(widget.photo.url)
-                : Container(),
+                : widget.photo != null && widget.photo.url != null
+                ? NetworkImage(widget.photo.url)
+                : AssetImage('res/icons/icMask.png'),
               minScale: PhotoViewComputedScale.contained * 0.8,
               maxScale: 4.0,
             ),
@@ -102,7 +108,8 @@ class _State extends State<PhotoDetail> {
                         ),
                       ),
                     ) : Container(),
-                    Container(
+                    widget.onPressDelete != null
+                    ? Container(
                       width: 60.0,
                       height: 60.0,
                       child: RawMaterialButton(
@@ -114,7 +121,7 @@ class _State extends State<PhotoDetail> {
                           color: Colors.white,
                         ),
                       ),
-                    ),
+                    ) : Container(),
                   ],
                 ),
               ),

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -1,0 +1,118 @@
+import 'package:bookoo2/models/User.dart';
+import 'package:bookoo2/screens/photo_detail.dart';
+import 'package:bookoo2/utils/general.dart' as prefix0;
+import 'package:flutter/material.dart';
+
+import 'package:bookoo2/shared/header.dart' show renderHeaderClose;
+import 'package:bookoo2/shared/edit_text_box.dart' show EditTextBox;
+import 'package:bookoo2/shared/profile_image_cam.dart';
+import 'package:bookoo2/utils/general.dart';
+import 'package:bookoo2/utils/localization.dart' show Localization;
+import 'package:bookoo2/utils/asset.dart' as Asset;
+import 'package:bookoo2/utils/validator.dart' show Validator;
+
+class ProfilePeer extends StatefulWidget {
+  final User user;
+
+  ProfilePeer({
+    @required this.user,
+  });
+
+  @override
+  _ProfilePeerState createState() => _ProfilePeerState();
+}
+
+class _ProfilePeerState extends State<ProfilePeer> {
+  void showImage(String photoUrl) async {
+
+    var _result = await General.instance.navigateScreen(
+      context,
+      MaterialPageRoute(
+        builder: (BuildContext context) => PhotoDetail(
+          photoUrl: photoUrl,
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    var _localization = Localization.of(context);
+
+    return Scaffold(
+      appBar: renderHeaderClose(
+        context: context,
+        brightness: Theme.of(context).brightness,
+      ),
+      body: SafeArea(
+        child: ListView(
+          padding: EdgeInsets.symmetric(horizontal: 40.0),
+          children: <Widget>[
+            Container(
+              margin: EdgeInsets.only(top: 24, bottom: 8),
+              child: Row(
+                children: <Widget>[
+                  Container(
+                    width: 88,
+                    height: 88,
+                    child: Material(
+                      clipBehavior: Clip.hardEdge,
+                      color: Colors.transparent,
+                      child: FlatButton(
+                        onPressed: () => showImage('https://picsum.photos/250?image=9'),
+                        padding: EdgeInsets.all(0.0),
+                        child: ClipOval(
+                          child: FadeInImage.assetNetwork(
+                            fit: BoxFit.cover,
+                            placeholder: 'res/icons/icMask.png',
+                            image: 'https://picsum.photos/250?image=9',
+                          ),
+                        ),
+                      ),
+                    ),
+                  )
+                ],
+              ),
+            ),
+            EditTextBox(
+              iconData: Icons.person_outline,
+              margin: EdgeInsets.only(top: 24.0),
+              hintText: _localization.trans('NICKNAME'),
+              focusedColor: Theme.of(context).textTheme.title.color,
+              enabledColor: Theme.of(context).textTheme.subtitle.color,
+              enabled: false,
+            ),
+            EditTextBox(
+              iconData: Icons.email,
+              margin: EdgeInsets.only(top: 8.0),
+              hintText: _localization.trans('EMAIL'),
+              focusedColor: Theme.of(context).textTheme.title.color,
+              enabledColor: Theme.of(context).textTheme.subtitle.color,
+              enabled: false,
+            ),
+            EditTextBox(
+              iconData: Icons.phone,
+              margin: EdgeInsets.only(top: 8.0),
+              hintText: _localization.trans('PHONE'),
+              focusedColor: Theme.of(context).textTheme.title.color,
+              enabledColor: Theme.of(context).textTheme.subtitle.color,
+              enabled: false,
+            ),
+            Container(
+              margin: EdgeInsets.only(top: 32.0, bottom: 12.0),
+              child: Divider(
+                height: 1.0,
+              ),
+            ),
+            EditTextBox(
+              labelText: _localization.trans('STATUS_MESSAGE'),
+              hintText: _localization.trans('STATUS_MESSAGE_HINT'),
+              maxLines: 5,
+              enabled: false,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_peer.dart
+++ b/lib/screens/profile_peer.dart
@@ -1,15 +1,11 @@
 import 'package:bookoo2/models/User.dart';
 import 'package:bookoo2/screens/photo_detail.dart';
-import 'package:bookoo2/utils/general.dart' as prefix0;
 import 'package:flutter/material.dart';
 
 import 'package:bookoo2/shared/header.dart' show renderHeaderClose;
 import 'package:bookoo2/shared/edit_text_box.dart' show EditTextBox;
-import 'package:bookoo2/shared/profile_image_cam.dart';
 import 'package:bookoo2/utils/general.dart';
 import 'package:bookoo2/utils/localization.dart' show Localization;
-import 'package:bookoo2/utils/asset.dart' as Asset;
-import 'package:bookoo2/utils/validator.dart' show Validator;
 
 class ProfilePeer extends StatefulWidget {
   final User user;
@@ -75,28 +71,32 @@ class _ProfilePeerState extends State<ProfilePeer> {
               ),
             ),
             EditTextBox(
+              controller: TextEditingController(text: 'hello'),
               iconData: Icons.person_outline,
               margin: EdgeInsets.only(top: 24.0),
-              hintText: _localization.trans('NICKNAME'),
               focusedColor: Theme.of(context).textTheme.title.color,
               enabledColor: Theme.of(context).textTheme.subtitle.color,
               enabled: false,
+              borderStyle: BorderStyle.none,
+              borderWidth: 0,
             ),
             EditTextBox(
               iconData: Icons.email,
               margin: EdgeInsets.only(top: 8.0),
-              hintText: _localization.trans('EMAIL'),
               focusedColor: Theme.of(context).textTheme.title.color,
               enabledColor: Theme.of(context).textTheme.subtitle.color,
               enabled: false,
+              borderStyle: BorderStyle.none,
+              borderWidth: 0,
             ),
             EditTextBox(
               iconData: Icons.phone,
               margin: EdgeInsets.only(top: 8.0),
-              hintText: _localization.trans('PHONE'),
               focusedColor: Theme.of(context).textTheme.title.color,
               enabledColor: Theme.of(context).textTheme.subtitle.color,
               enabled: false,
+              borderStyle: BorderStyle.none,
+              borderWidth: 0,
             ),
             Container(
               margin: EdgeInsets.only(top: 32.0, bottom: 12.0),
@@ -105,10 +105,10 @@ class _ProfilePeerState extends State<ProfilePeer> {
               ),
             ),
             EditTextBox(
-              labelText: _localization.trans('STATUS_MESSAGE'),
-              hintText: _localization.trans('STATUS_MESSAGE_HINT'),
               maxLines: 5,
               enabled: false,
+              borderWidth: 0,
+              borderStyle: BorderStyle.none,
             ),
           ],
         ),

--- a/lib/shared/edit_text_box.dart
+++ b/lib/shared/edit_text_box.dart
@@ -4,6 +4,7 @@ import 'package:bookoo2/utils/asset.dart' as Asset;
 class EditTextBox extends StatefulWidget {
   const EditTextBox({
     this.key,
+    this.enabled = true,
     this.focusedColor = const Color.fromARGB(255, 66, 77, 107),
     this.enabledColor = const Color.fromARGB(255, 220, 226, 235),
     this.disabledColor = const Color.fromARGB(255, 211, 211, 211),
@@ -27,6 +28,7 @@ class EditTextBox extends StatefulWidget {
     this.controller,
   });
   final Key key;
+  final bool enabled;
   final TextEditingController controller;
   final Color focusedColor;
   final Color enabledColor;
@@ -74,6 +76,7 @@ class _EditTextBoxState extends State<EditTextBox> {
         ): Container(),
         Container(
           child: TextField(
+            enabled: widget.enabled,
             controller: widget.controller,
             style: widget.textStyle,
             cursorColor: widget.focusedColor,

--- a/lib/shared/edit_text_box.dart
+++ b/lib/shared/edit_text_box.dart
@@ -26,6 +26,8 @@ class EditTextBox extends StatefulWidget {
       color: Asset.Colors.carnation,
     ),
     this.controller,
+    this.borderWidth = 0.7,
+    this.borderStyle = BorderStyle.solid,
   });
   final Key key;
   final bool enabled;
@@ -48,6 +50,8 @@ class EditTextBox extends StatefulWidget {
   final TextStyle hintStyle;
   final String errorText;
   final TextStyle errorStyle;
+  final double borderWidth;
+  final BorderStyle borderStyle;
 
   @override
   _EditTextBoxState createState() => _EditTextBoxState();
@@ -78,7 +82,7 @@ class _EditTextBoxState extends State<EditTextBox> {
           child: TextField(
             enabled: widget.enabled,
             controller: widget.controller,
-            style: widget.textStyle,
+            style: widget.textStyle ?? TextStyle(color: Theme.of(context).textTheme.title.color),
             cursorColor: widget.focusedColor,
             onChanged: widget.onChangeText,
             maxLength: widget.maxLength,
@@ -103,35 +107,40 @@ class _EditTextBoxState extends State<EditTextBox> {
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
                   color: widget.focusedColor,
-                  width: 0.7,
+                  width: widget.borderWidth,
+                  style: widget.borderStyle,
                 ),
               ),
               enabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
                   color: widget.enabledColor,
-                  width: 0.7,
+                  width: widget.borderWidth,
+                  style: widget.borderStyle,
                 ),
               ),
               disabledBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
                   color: widget.disabledColor,
-                  width: 0.7,
+                  width: widget.borderWidth,
+                  style: widget.borderStyle,
                 ),
               ),
               errorBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
                   color: widget.errorStyle.color,
-                  width: 0.7,
+                  width: widget.borderWidth,
+                  style: widget.borderStyle,
                 ),
               ),
               focusedErrorBorder: OutlineInputBorder(
                 borderRadius: BorderRadius.all(Radius.zero),
                 borderSide: BorderSide(
                   color: widget.errorStyle.color,
-                  width: 0.7,
+                  width: widget.borderWidth,
+                  style: widget.borderStyle,
                 ),
               ),
             ),

--- a/lib/shared/member_horizontal_list.dart
+++ b/lib/shared/member_horizontal_list.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 
 import 'package:bookoo2/utils/asset.dart' as Asset;
 
-
 class MemberHorizontalList extends StatelessWidget {
   final bool showAddBtn;
   final Function onSeeAllPressed;

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -1,6 +1,8 @@
-import 'package:auto_size_text/auto_size_text.dart';
-import 'package:bookoo2/models/User.dart';
+import 'package:bookoo2/utils/localization.dart';
 import 'package:flutter/material.dart';
+import 'package:auto_size_text/auto_size_text.dart';
+
+import 'package:bookoo2/models/User.dart';
 import 'package:bookoo2/utils/asset.dart' as Asset;
 
 abstract class ListItem {}
@@ -15,28 +17,27 @@ class HeadingItem implements ListItem {
 
 class MemberItem implements ListItem {
   final User user;
-  final Membership membership;
 
-  MemberItem(this.user, this.membership);
+  MemberItem(this.user);
 }
 
 class MemberListItem extends StatelessWidget {
   final Key key;
   final User user;
-  final Membership membership;
   final Function onPressMember;
   final Function onPressAuth;
 
   const MemberListItem({
     this.key,
     @required this.user,
-    @required this.membership,
     this.onPressMember,
     this.onPressAuth,
   });
 
   @override
   Widget build(BuildContext context) {
+    var _localization = Localization.of(context);
+
     return Container(
       height: 80,
       alignment: Alignment(-1, 0),
@@ -60,12 +61,12 @@ class MemberListItem extends StatelessWidget {
                           height: 40,
                         ),
                       ),
-                      membership == Membership.Owner
+                      user.membership == Membership.Owner
                       ? Positioned(
                         bottom: 0,
                         right: 0,
                         child: Image(
-                          image: membership == Membership.Owner
+                          image: user.membership == Membership.Owner
                             ? Asset.Icons.icOwner
                             : Asset.Icons.icOwner,
                           width: 20,
@@ -115,11 +116,11 @@ class MemberListItem extends StatelessWidget {
               padding: EdgeInsets.all(0),
               onPressed: this.onPressAuth,
               child: Text(
-                membership == Membership.Owner
-                ? 'Owner'
-                : membership == Membership.Writer
-                ? 'Writer'
-                : 'Guest',
+                user.membership == Membership.Owner
+                ? _localization.trans('MEMBER_OWNER')
+                : user.membership == Membership.Admin
+                ? _localization.trans('MEMBER_ADMIN')
+                : _localization.trans('MEMBER_GUEST'),
                 style: TextStyle(
                   fontSize: 12,
                   color: Theme.of(context).textTheme.display2.color,

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -45,6 +45,7 @@ class MemberListItem extends StatelessWidget {
               child: Row(
                 children: <Widget>[
                   Stack(
+                    alignment: AlignmentDirectional.center,
                     children: <Widget>[
                       Container(
                         width: 52,

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -24,11 +24,15 @@ class MemberListItem extends StatelessWidget {
   final Key key;
   final User user;
   final Membership membership;
+  final Function onPressMember;
+  final Function onPressAuth;
 
   const MemberListItem({
     this.key,
     @required this.user,
     @required this.membership,
+    this.onPressMember,
+    this.onPressAuth,
   });
 
   @override
@@ -40,7 +44,7 @@ class MemberListItem extends StatelessWidget {
         children: <Widget>[
           Expanded(
             child: FlatButton(
-              onPressed: () {},
+              onPressed: this.onPressMember,
               padding: EdgeInsets.symmetric(horizontal: 40),
               child: Row(
                 children: <Widget>[
@@ -109,7 +113,7 @@ class MemberListItem extends StatelessWidget {
             height: double.infinity,
             child: FlatButton(
               padding: EdgeInsets.all(0),
-              onPressed: () {},
+              onPressed: this.onPressAuth,
               child: Text(
                 membership == Membership.Owner
                 ? 'Owner'

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -1,3 +1,4 @@
+import 'package:auto_size_text/auto_size_text.dart';
 import 'package:bookoo2/models/User.dart';
 import 'package:flutter/material.dart';
 import 'package:bookoo2/utils/asset.dart' as Asset;
@@ -34,14 +35,13 @@ class MemberListItem extends StatelessWidget {
   Widget build(BuildContext context) {
     return Container(
       height: 80,
-      padding: EdgeInsets.symmetric(horizontal: 40),
       alignment: Alignment(-1, 0),
       child: Row(
         children: <Widget>[
           Expanded(
             child: FlatButton(
               onPressed: () {},
-              padding: EdgeInsets.all(0),
+              padding: EdgeInsets.symmetric(horizontal: 40),
               child: Row(
                 children: <Widget>[
                   Stack(
@@ -70,39 +70,43 @@ class MemberListItem extends StatelessWidget {
                       ) : Container(),
                     ],
                   ),
-                  Container(
-                    margin: EdgeInsets.only(left: 20),
-                    child: Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          user.email,
-                          style: TextStyle(
-                            fontSize: 18,
-                            color: Theme.of(context).textTheme.title.color,
-                          ),
-                        ),
-                        Container(
-                          margin: EdgeInsets.only(top: 4),
-                          child: Text(
+                  Expanded(
+                    child: Container(
+                      margin: EdgeInsets.only(left: 20),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          AutoSizeText(
                             user.email,
+                            maxLines: 1,
                             style: TextStyle(
-                              fontSize: 14,
-                              color: Theme.of(context).textTheme.display2.color,
+                              fontSize: 18,
+                              color: Theme.of(context).textTheme.title.color,
                             ),
                           ),
-                        ),
-                      ],
+                          Container(
+                            margin: EdgeInsets.only(top: 4),
+                            child: AutoSizeText(
+                              user.email,
+                              style: TextStyle(
+                                fontSize: 14,
+                                color: Theme.of(context).textTheme.display2.color,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
                     ),
-                  )
+                  ),
                 ],
               ),
             ),
           ),
           Container(
             alignment: Alignment(0,0),
-            width: 60,
+            width: 80,
+            height: double.infinity,
             child: FlatButton(
               padding: EdgeInsets.all(0),
               onPressed: () {},

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -83,7 +83,7 @@ class MemberListItem extends StatelessWidget {
                         crossAxisAlignment: CrossAxisAlignment.start,
                         children: <Widget>[
                           AutoSizeText(
-                            user.email,
+                            user.displayName,
                             maxLines: 1,
                             style: TextStyle(
                               fontSize: 18,

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -1,5 +1,6 @@
 import 'package:bookoo2/models/User.dart';
 import 'package:flutter/material.dart';
+import 'package:bookoo2/utils/asset.dart' as Asset;
 
 abstract class ListItem {}
 
@@ -32,7 +33,93 @@ class MemberListItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      child: Text('member list item'),
+      height: 80,
+      padding: EdgeInsets.symmetric(horizontal: 40),
+      alignment: Alignment(-1, 0),
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: FlatButton(
+              onPressed: () {},
+              padding: EdgeInsets.all(0),
+              child: Row(
+                children: <Widget>[
+                  Stack(
+                    children: <Widget>[
+                      Container(
+                        width: 52,
+                        height: 52,
+                        child: Image(
+                          image: Asset.Icons.icMask,
+                          width: 40,
+                          height: 40,
+                        ),
+                      ),
+                      membership == Membership.Owner
+                      ? Positioned(
+                        bottom: 0,
+                        right: 0,
+                        child: Image(
+                          image: membership == Membership.Owner
+                            ? Asset.Icons.icOwner
+                            : Asset.Icons.icOwner,
+                          width: 20,
+                          height: 20,
+                        ),
+                      ) : Container(),
+                    ],
+                  ),
+                  Container(
+                    margin: EdgeInsets.only(left: 20),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          user.email,
+                          style: TextStyle(
+                            fontSize: 18,
+                            color: Theme.of(context).textTheme.title.color,
+                          ),
+                        ),
+                        Container(
+                          margin: EdgeInsets.only(top: 4),
+                          child: Text(
+                            user.email,
+                            style: TextStyle(
+                              fontSize: 14,
+                              color: Theme.of(context).textTheme.display2.color,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  )
+                ],
+              ),
+            ),
+          ),
+          Container(
+            alignment: Alignment(0,0),
+            width: 60,
+            child: FlatButton(
+              padding: EdgeInsets.all(0),
+              onPressed: () {},
+              child: Text(
+                membership == Membership.Owner
+                ? 'Owner'
+                : membership == Membership.Writer
+                ? 'Writer'
+                : 'Guest',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: Theme.of(context).textTheme.display2.color,
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/shared/member_list_item.dart
+++ b/lib/shared/member_list_item.dart
@@ -1,0 +1,38 @@
+import 'package:bookoo2/models/User.dart';
+import 'package:flutter/material.dart';
+
+abstract class ListItem {}
+
+class HeadingItem implements ListItem {
+  final int numOfPeople;
+
+  HeadingItem({
+    this.numOfPeople = 0,
+  });
+}
+
+class MemberItem implements ListItem {
+  final User user;
+  final Membership membership;
+
+  MemberItem(this.user, this.membership);
+}
+
+class MemberListItem extends StatelessWidget {
+  final Key key;
+  final User user;
+  final Membership membership;
+
+  const MemberListItem({
+    this.key,
+    @required this.user,
+    @required this.membership,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      child: Text('member list item'),
+    );
+  }
+}

--- a/lib/shared/profile_image_cam.dart
+++ b/lib/shared/profile_image_cam.dart
@@ -26,34 +26,33 @@ class ProfileImageCam extends StatelessWidget {
                 height: 88.0,
                 child: ClipOval(
                   child: this.imgStr == null || this.imgStr == ''
-                    ? Material(
-                      clipBehavior: Clip.hardEdge,
-                      color: Colors.transparent,
-                      child: Ink.image(
-                        image: Asset.Icons.icMask,
-                        fit: BoxFit.cover,
-                        width: 80.0,
-                        height: 80.0,
-                        child: InkWell(
-                          onTap: this.selectGallery,
-                        ),
-                      )
-                    )
-                    : Material(
-                      clipBehavior: Clip.hardEdge,
-                      color: Colors.transparent,
-                      child: FlatButton(
-                        onPressed: this.selectGallery,
-                        padding: EdgeInsets.all(0.0),
-                        child: ClipOval(
-                          child: FadeInImage.assetNetwork(
+                      ? Material(
+                          clipBehavior: Clip.hardEdge,
+                          color: Colors.transparent,
+                          child: Ink.image(
+                            image: Asset.Icons.icMask,
                             fit: BoxFit.cover,
-                            placeholder: 'res/icons/icMask.png',
-                            image: 'https://picsum.photos/250?image=9',
+                            width: 80.0,
+                            height: 80.0,
+                            child: InkWell(
+                              onTap: this.selectGallery,
+                            ),
+                          ))
+                      : Material(
+                          clipBehavior: Clip.hardEdge,
+                          color: Colors.transparent,
+                          child: FlatButton(
+                            onPressed: this.selectGallery,
+                            padding: EdgeInsets.all(0.0),
+                            child: ClipOval(
+                              child: FadeInImage.assetNetwork(
+                                fit: BoxFit.cover,
+                                placeholder: 'res/icons/icMask.png',
+                                image: 'https://picsum.photos/250?image=9',
+                              ),
+                            ),
                           ),
                         ),
-                      ),
-                    )
                 ),
               ),
               Positioned(

--- a/lib/utils/general.dart
+++ b/lib/utils/general.dart
@@ -21,7 +21,8 @@ class General {
     return cursorPos;
   }
 
-  Future<Object> navigateScreenNamed(BuildContext context, String routeName, { bool reset = false }) {
+  Future<Object> navigateScreenNamed(BuildContext context, String routeName,
+      {bool reset = false}) {
     if (reset) {
       return Navigator.pushNamedAndRemoveUntil(
         context,
@@ -32,14 +33,16 @@ class General {
     return Navigator.of(context).pushNamed(routeName);
   }
 
-  Future<dynamic> navigateScreen(BuildContext context, MaterialPageRoute pageRoute) {
+  Future<dynamic> navigateScreen(
+      BuildContext context, MaterialPageRoute pageRoute) {
     return Navigator.push(
       context,
       pageRoute,
     );
   }
 
-  void showDialogSpinner(BuildContext context, {
+  void showDialogSpinner(
+    BuildContext context, {
     String text,
     TextStyle textStyle,
   }) {
@@ -49,13 +52,14 @@ class General {
         builder: (BuildContext context) {
           return DialogSpinner(
             textStyle: textStyle,
-            text: text != null ? text : Localization.of(context).trans('LOADING'),
+            text:
+                text != null ? text : Localization.of(context).trans('LOADING'),
           );
-        }
-    );
+        });
   }
 
-  void showSingleDialog(BuildContext context, {
+  void showSingleDialog(
+    BuildContext context, {
     bool barrierDismissible = false,
     String title = '',
     String content = '',
@@ -88,7 +92,8 @@ class General {
     );
   }
 
-  void showConfirmDialog(BuildContext context, {
+  void showConfirmDialog(
+    BuildContext context, {
     bool barrierDismissible = false,
     String title = '',
     String content = '',
@@ -127,6 +132,48 @@ class General {
     );
   }
 
+  void showMembershipDialog(
+      BuildContext context, Function onChange, int value) {
+    var _localization = Localization.of(context);
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(_localization.trans('MEMBERSHIP_CHANGE')),
+          content: StatefulBuilder(
+            builder: (BuildContext context, StateSetter setState) {
+              return Container(
+                height: 200,
+                child: Column(
+                  children: <Widget>[
+                    RadioListTile(
+                      title: Text(_localization.trans('MEMBER_OWNER')),
+                      groupValue: value,
+                      value: 0,
+                      onChanged: onChange,
+                    ),
+                    RadioListTile(
+                      title: Text(_localization.trans('MEMBER_ADMIN')),
+                      groupValue: value,
+                      value: 1,
+                      onChanged: onChange,
+                    ),
+                    RadioListTile(
+                      title: Text(_localization.trans('MEMBER_GUEST')),
+                      groupValue: value,
+                      value: 2,
+                      onChanged: onChange,
+                    ),
+                  ],
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+
   void showSnackBar(BuildContext context, String str, String btnStr) {
     var snackBar = SnackBar(
       content: Text(str),
@@ -153,12 +200,13 @@ class General {
 
     showModalBottomSheet(
         context: context,
-        builder: (builder){
+        builder: (builder) {
           return Container(
             color: Color.fromRGBO(240, 240, 240, 1.0),
             child: ListView.builder(
               itemBuilder: (BuildContext context, int index) {
-                var datum = '${data[index].year}/${data[index].month}/${data[index].day}';
+                var datum =
+                    '${data[index].year}/${data[index].month}/${data[index].day}';
                 return Container(
                   child: FlatButton(
                     onPressed: () {
@@ -174,10 +222,10 @@ class General {
                             child: Text(
                               datum,
                               style: TextStyle(
-                                color:  Colors.black,
+                                color: Colors.black,
                                 fontWeight: FontWeight.w400,
                                 fontFamily: "AppleSDGothicNeo",
-                                fontStyle:  FontStyle.normal,
+                                fontStyle: FontStyle.normal,
                                 fontSize: 18.0,
                               ),
                             ),
@@ -191,20 +239,20 @@ class General {
               itemCount: data.length,
             ),
           );
-        }
-    );
+        });
   }
 
   Future<File> chooseImage({
     @required BuildContext context,
     String type,
   }) async {
-    General.instance.showDialogSpinner(context, text: Localization.of(context).trans('LOADING'));
+    General.instance.showDialogSpinner(context,
+        text: Localization.of(context).trans('LOADING'));
 
     try {
       File imgFile = type == 'camera'
-        ? await ImagePicker.pickImage(source: ImageSource.camera)
-        : await ImagePicker.pickImage(source: ImageSource.gallery);
+          ? await ImagePicker.pickImage(source: ImageSource.camera)
+          : await ImagePicker.pickImage(source: ImageSource.gallery);
       return imgFile;
     } catch (err) {
       print('chooseImage err $err');
@@ -214,7 +262,7 @@ class General {
     }
   }
 
-  File compressImage(File img, { int size = 500 }) {
+  File compressImage(File img, {int size = 500}) {
     Im.Image image = Im.decodeImage(img.readAsBytesSync());
     Im.Image smallerImage = Im.copyResize(image, width: size, height: size);
     return smallerImage as File;

--- a/res/langs/en.json
+++ b/res/langs/en.json
@@ -145,5 +145,6 @@
   "MEMBERSHIP_CHANGE": "Change membership",
   "MEMBER_OWNER": "Owner",
   "MEMBER_ADMIN": "Admin",
-  "MEMBER_GUEST": "Guest"
+  "MEMBER_GUEST": "Guest",
+  "SEARCH_USER_HINT": "Search user..."
 }

--- a/res/langs/en.json
+++ b/res/langs/en.json
@@ -141,5 +141,9 @@
   "LOCK_HINT": "Please Enter PIN code.",
   "FINGERPRINT_LOGIN": "Unlock with Fingerprint",
   "FINGERPRINT_SET": "FingerPrint Setup",
-  "PIN_MISMATCH": "PIN code mismatch"
+  "PIN_MISMATCH": "PIN code mismatch",
+  "MEMBERSHIP_CHANGE": "Change membership",
+  "MEMBER_OWNER": "Owner",
+  "MEMBER_ADMIN": "Admin",
+  "MEMBER_GUEST": "Guest"
 }

--- a/res/langs/ko.json
+++ b/res/langs/ko.json
@@ -141,5 +141,9 @@
   "LOCK_HINT": "잠금암호 네자리를 입력해주세요.",
   "FINGERPRINT_LOGIN": "지문으로 해제",
   "FINGERPRINT_SET": "지문 설정",
-  "PIN_MISMATCH": "잠금 암호가 일치하지 않습니다."
+  "PIN_MISMATCH": "잠금 암호가 일치하지 않습니다.",
+  "MEMBERSHIP_CHANGE": "멤버쉽 변경",
+  "MEMBER_OWNER": "오너",
+  "MEMBER_ADMIN": "관리자",
+  "MEMBER_GUEST": "손님"
 }

--- a/res/langs/ko.json
+++ b/res/langs/ko.json
@@ -145,5 +145,6 @@
   "MEMBERSHIP_CHANGE": "멤버쉽 변경",
   "MEMBER_OWNER": "오너",
   "MEMBER_ADMIN": "관리자",
-  "MEMBER_GUEST": "손님"
+  "MEMBER_GUEST": "손님",
+  "SEARCH_USER_HINT": "Search user..."
 }


### PR DESCRIPTION
- [x] Create [Members] screen
- [x] Navigate from [LedgerAdd] screen
- [x] Create [ProfilePeer] screen
- [x] Create [MemberListItem] shared widget
   - [x] Member has three permissions (Owner, Writer, Reader)
   - [x] Clicking on member will show [Member] screen.
   - [x] Clicking on option button will show `auth` change pop up.
   - [x] Ability to change the user's `membership` from `AlertDialog` that contains `RadioList`.
- [x] Show `TextInput` when clicking on `Search` action icon
- [x] Make the member filterable